### PR TITLE
Support no marker for boundary facets

### DIFF
--- a/cpp/demo/biharmonic/main.cpp
+++ b/cpp/demo/biharmonic/main.cpp
@@ -207,23 +207,7 @@ int main(int argc, char* argv[])
     //  follows:
 
     //  Define boundary condition
-    auto facets = mesh::locate_entities_boundary(
-        *mesh, 1,
-        [](auto x)
-        {
-          constexpr U eps = 1.0e-6;
-          std::vector<std::int8_t> marker(x.extent(1), false);
-          for (std::size_t p = 0; p < x.extent(1); ++p)
-          {
-            U x0 = x(0, p);
-            U x1 = x(1, p);
-            if (std::abs(x0) < eps or std::abs(x0 - 1) < eps)
-              marker[p] = true;
-            if (std::abs(x1) < eps or std::abs(x1 - 1) < eps)
-              marker[p] = true;
-          }
-          return marker;
-        });
+    auto facets = mesh::locate_entities_boundary(*mesh, 1);
     const auto bdofs = fem::locate_dofs_topological(
         *V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
     auto bc = std::make_shared<const fem::DirichletBC<T>>(0.0, bdofs, V);

--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -126,8 +126,6 @@ else:
 from mpi4py import MPI
 
 # +
-import numpy as np
-
 import dolfinx
 import ufl
 from dolfinx import fem, io, mesh, plot
@@ -165,14 +163,7 @@ V = fem.functionspace(msh, ("Lagrange", 2))
 # function that returns `True` for points `x` on the boundary and
 # `False` otherwise.
 
-facets = mesh.locate_entities_boundary(
-    msh,
-    dim=1,
-    marker=lambda x: np.isclose(x[0], 0.0)
-    | np.isclose(x[0], 1.0)
-    | np.isclose(x[1], 0.0)
-    | np.isclose(x[1], 1.0),
-)
+facets = mesh.locate_entities_boundary(msh, dim=1)
 
 # We now find the degrees-of-freedom that are associated with the
 # boundary facets using {py:func}`locate_dofs_topological

--- a/python/demo/demo_hdg.py
+++ b/python/demo/demo_hdg.py
@@ -82,19 +82,6 @@ def u_e(x):
     return u_e
 
 
-def boundary(x):
-    """Boundary marker."""
-    lr = np.isclose(x[0], 0.0) | np.isclose(x[0], 1.0)
-    tb = np.isclose(x[1], 0.0) | np.isclose(x[1], 1.0)
-    lrtb = lr | tb
-    if tdim == 2:
-        return lrtb
-    else:
-        assert tdim == 3
-        fb = np.isclose(x[2], 0.0) | np.isclose(x[2], 1.0)
-        return lrtb | fb
-
-
 comm = MPI.COMM_WORLD
 rank = comm.rank
 dtype = PETSc.ScalarType
@@ -187,7 +174,7 @@ L = [L_0, L_1]
 
 # Apply Dirichlet boundary conditions
 # We begin by locating the boundary facets of msh
-msh_boundary_facets = mesh.locate_entities_boundary(msh, fdim, boundary)
+msh_boundary_facets = mesh.locate_entities_boundary(msh, fdim)
 # Since the boundary condition is enforced in the facet space, we must
 # use the mesh_to_facet_mesh map to get the corresponding facets in
 # facet_mesh

--- a/python/demo/demo_navier-stokes.py
+++ b/python/demo/demo_navier-stokes.py
@@ -261,15 +261,6 @@ def f_expr(x):
     return np.vstack((np.zeros_like(x[0]), np.zeros_like(x[0])))
 
 
-def boundary_marker(x):
-    return (
-        np.isclose(x[0], 0.0)
-        | np.isclose(x[0], 1.0)
-        | np.isclose(x[1], 0.0)
-        | np.isclose(x[1], 1.0)
-    )
-
-
 # -
 
 # We define some simulation parameters
@@ -344,7 +335,7 @@ L_1 = inner(fem.Constant(msh, default_real_type(0.0)), q) * dx
 L = fem.form([L_0, L_1])
 
 # Boundary conditions
-boundary_facets = mesh.locate_entities_boundary(msh, msh.topology.dim - 1, boundary_marker)
+boundary_facets = mesh.locate_entities_boundary(msh, msh.topology.dim - 1)
 boundary_vel_dofs = fem.locate_dofs_topological(V, msh.topology.dim - 1, boundary_facets)
 bc_u = fem.dirichletbc(u_D, boundary_vel_dofs)
 bcs = [bc_u]

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -238,7 +238,9 @@ def locate_entities(mesh: Mesh, dim: int, marker: typing.Callable) -> np.ndarray
     return _cpp.mesh.locate_entities(mesh._cpp_object, dim, marker)
 
 
-def locate_entities_boundary(mesh: Mesh, dim: int, marker: typing.Callable) -> np.ndarray:
+def locate_entities_boundary(
+    mesh: Mesh, dim: int, marker: typing.Optional[typing.Callable] = None
+) -> np.ndarray:
     """Compute mesh entities that are connected to an owned boundary
     facet and satisfy a geometric marking function.
 

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -301,14 +301,7 @@ def test_mixed_dom_codim_1(n, k):
 
     # Create a submesh of the boundary
     tdim = msh.topology.dim
-    boundary_facets = locate_entities_boundary(
-        msh,
-        tdim - 1,
-        lambda x: np.isclose(x[0], 0.0)
-        | np.isclose(x[0], 1.0)
-        | np.isclose(x[1], 0.0)
-        | np.isclose(x[1], 1.0),
-    )
+    boundary_facets = locate_entities_boundary(msh, tdim - 1)
 
     smsh, smsh_to_msh = create_submesh(msh, tdim - 1, boundary_facets)[:2]
 

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -119,9 +119,7 @@ def test_constant_bc_constructions():
     V2 = functionspace(msh, ("Lagrange", 1, (gdim, gdim)))
 
     tdim = msh.topology.dim
-    boundary_facets = locate_entities_boundary(
-        msh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool)
-    )
+    boundary_facets = locate_entities_boundary(msh, tdim - 1)
     boundary_dofs0 = locate_dofs_topological(V0, tdim - 1, boundary_facets)
     boundary_dofs1 = locate_dofs_topological(V1, tdim - 1, boundary_facets)
     boundary_dofs2 = locate_dofs_topological(V2, tdim - 1, boundary_facets)
@@ -166,9 +164,7 @@ def test_constant_bc(mesh_factory):
     V = functionspace(mesh, ("Lagrange", 1))
     c = default_scalar_type(2)
     tdim = mesh.topology.dim
-    boundary_facets = locate_entities_boundary(
-        mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool)
-    )
+    boundary_facets = locate_entities_boundary(mesh, tdim - 1)
 
     boundary_dofs = locate_dofs_topological(V, tdim - 1, boundary_facets)
 
@@ -205,9 +201,7 @@ def test_vector_constant_bc(mesh_factory):
     V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     assert V.num_sub_spaces == gdim
     c = np.arange(1, mesh.geometry.dim + 1, dtype=default_scalar_type)
-    boundary_facets = locate_entities_boundary(
-        mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool)
-    )
+    boundary_facets = locate_entities_boundary(mesh, tdim - 1)
 
     # Set using sub-functions
     Vs = [V.sub(i).collapse()[0] for i in range(V.num_sub_spaces)]
@@ -252,9 +246,7 @@ def test_sub_constant_bc(mesh_factory):
     V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     c = Constant(mesh, default_scalar_type(3.14))
     tdim = mesh.topology.dim
-    boundary_facets = locate_entities_boundary(
-        mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool)
-    )
+    boundary_facets = locate_entities_boundary(mesh, tdim - 1)
 
     for i in range(V.num_sub_spaces):
         Vi = V.sub(i).collapse()[0]
@@ -288,9 +280,7 @@ def test_mixed_constant_bc(mesh_factory):
     func, args = mesh_factory
     mesh = func(*args)
     tdim = mesh.topology.dim
-    boundary_facets = locate_entities_boundary(
-        mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool)
-    )
+    boundary_facets = locate_entities_boundary(mesh, tdim - 1)
     TH = mixed_element(
         [
             element("Lagrange", mesh.basix_cell(), 1, dtype=default_real_type),
@@ -330,9 +320,7 @@ def test_mixed_blocked_constant():
     Dirichlet BC based on a vector valued Constant."""
     mesh = create_unit_square(MPI.COMM_WORLD, 4, 4)
     tdim = mesh.topology.dim
-    boundary_facets = locate_entities_boundary(
-        mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool)
-    )
+    boundary_facets = locate_entities_boundary(mesh, tdim - 1)
 
     TH = mixed_element(
         [

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -250,9 +250,7 @@ def test_petsc_curl_curl_eigenvalue(family, order):
     a = inner(ufl.curl(u), ufl.curl(v)) * dx
     b = inner(u, v) * dx
 
-    boundary_facets = locate_entities_boundary(
-        mesh, mesh.topology.dim - 1, lambda x: np.full(x.shape[1], True, dtype=bool)
-    )
+    boundary_facets = locate_entities_boundary(mesh, mesh.topology.dim - 1)
     boundary_dofs = locate_dofs_topological(V, mesh.topology.dim - 1, boundary_facets)
 
     zero_u = Function(V)
@@ -377,9 +375,7 @@ def test_biharmonic(family, dtype):
 
     # Strong (Dirichlet) boundary condition
     tdim = mesh.topology.dim
-    boundary_facets = locate_entities_boundary(
-        mesh, tdim - 1, lambda x: np.full(x.shape[1], True, dtype=bool)
-    )
+    boundary_facets = locate_entities_boundary(mesh, tdim - 1)
     boundary_dofs = locate_dofs_topological((V.sub(1), V_1), tdim - 1, boundary_facets)
 
     bcs = [dirichletbc(zero_u, boundary_dofs, V.sub(1))]


### PR DESCRIPTION
This allows for the usage of `locate_entities_boundary` without providing a 'all true' marker to identify all boundary facets. This increases readability of the use cases, which before had to manually encode this all true function, done in different ways, and refrains from evaluating any marker in these cases altogether. 

Fixes https://github.com/schnellerhase/dolfinx/issues/16