### PR TITLE
1d refinement

### DIFF
--- a/cpp/dolfinx/refinement/CMakeLists.txt
+++ b/cpp/dolfinx/refinement/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(HEADERS_refinement
     ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_refinement.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/plaza.h ${CMAKE_CURRENT_SOURCE_DIR}/refine.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/plaza.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/refine.h
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
     PARENT_SCOPE
 )

--- a/cpp/dolfinx/refinement/CMakeLists.txt
+++ b/cpp/dolfinx/refinement/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(HEADERS_refinement
     ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_refinement.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/interval.h
     ${CMAKE_CURRENT_SOURCE_DIR}/plaza.h
     ${CMAKE_CURRENT_SOURCE_DIR}/refine.h
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.h

--- a/cpp/dolfinx/refinement/dolfinx_refinement.h
+++ b/cpp/dolfinx/refinement/dolfinx_refinement.h
@@ -11,3 +11,4 @@ namespace dolfinx::refinement
 // DOLFINx refinement interface
 
 #include <dolfinx/refinement/refine.h>
+#include <dolfinx/refinement/interval.h>

--- a/cpp/dolfinx/refinement/interval.h
+++ b/cpp/dolfinx/refinement/interval.h
@@ -1,0 +1,235 @@
+// Copyright (C) 2024 Paul Kühner
+//
+// This file is part of DOLFINX (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <mpi.h>
+
+#include <concepts>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+#include "dolfinx/mesh/Mesh.h"
+#include "dolfinx/mesh/cell_types.h"
+#include "dolfinx/mesh/utils.h"
+#include "dolfinx/refinement/plaza.h"
+
+namespace dolfinx::refinement
+{
+
+namespace impl
+{
+
+/// Refine with markers returning new mesh data.
+///
+/// @param[in] mesh Input mesh to be refined
+/// @param[in] edges Indices of the edges that are marked for refinement
+///
+/// @return New mesh data: cell topology, vertex coordinates and parent
+/// edge indices.
+template <std::floating_point T>
+std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<T>,
+           std::array<std::size_t, 2>, std::vector<std::int32_t>>
+compute_interval_refinement(const mesh::Mesh<T>& mesh,
+                            std::optional<std::span<const std::int32_t>> edges)
+{
+  auto topology = mesh.topology();
+  assert(topology);
+  assert(topology->dim() == 1);
+
+  auto map_e = topology->index_map(1);
+  assert(map_e);
+
+  // TODO: creation of sharing ranks in external function? Also same code in use
+  // for plaza
+  // Get sharing ranks for each edge
+  graph::AdjacencyList<int> edge_ranks = map_e->index_to_dest_ranks();
+
+  // Create unique list of ranks that share edges (owners of ghosts plus
+  // ranks that ghost owned indices)
+  std::vector<int> ranks = edge_ranks.array();
+  std::ranges::sort(ranks);
+  auto to_remove = std::ranges::unique(ranks);
+  ranks.erase(to_remove.begin(), to_remove.end());
+
+  // Convert edge_ranks from global rank to to neighbourhood ranks
+  std::ranges::transform(edge_ranks.array(), edge_ranks.array().begin(),
+                         [&ranks](auto r)
+                         {
+                           auto it = std::lower_bound(ranks.begin(),
+                                                      ranks.end(), r);
+                           assert(it != ranks.end() and *it == r);
+                           return std::distance(ranks.begin(), it);
+                         });
+
+  // create refinement flag for edges
+  // TODO: vector of bools? -> make of use std specialization for type bool
+  std::vector<std::int8_t> refinement_marker(
+      map_e->size_local() + map_e->num_ghosts(), !edges.has_value());
+
+  // mark edges for refinement
+  std::vector<std::vector<std::int32_t>> marked_for_update(ranks.size());
+  if (edges.has_value())
+  {
+    std::ranges::for_each(edges.value(),
+                          [&](auto edge)
+                          {
+                            if (!refinement_marker[edge])
+                            {
+                              refinement_marker[edge] = true;
+                              for (int rank : edge_ranks.links(edge))
+                                marked_for_update[rank].push_back(edge);
+                            }
+                          });
+  }
+
+  // create neighborhood communicator for vertex creation
+  MPI_Comm neighbor_comm;
+  MPI_Dist_graph_create_adjacent(
+      mesh.comm(), ranks.size(), ranks.data(), MPI_UNWEIGHTED, ranks.size(),
+      ranks.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false, &neighbor_comm);
+
+  // Communicate ghost edges that might have been marked. This is not necessary
+  // for a uniform refinement.
+  if (edges.has_value())
+    update_logical_edgefunction(neighbor_comm, marked_for_update,
+                                refinement_marker, *map_e);
+
+  // Construct the new vertices
+  const auto [new_vertex_map, new_vertex_coords, xshape]
+      = create_new_vertices(neighbor_comm, edge_ranks, mesh, refinement_marker);
+  MPI_Comm_free(&neighbor_comm);
+
+  auto e_to_v = mesh.topology()->connectivity(1, 0);
+  assert(e_to_v);
+
+  // get the count of edges to refine, note: we only consider non-ghost edges
+  std::int32_t number_of_refined_edges
+      = std::count(refinement_marker.begin(),
+                   std::next(refinement_marker.begin(),
+                             mesh.topology()->index_map(1)->size_local()),
+                   true);
+
+  // Produce local global indices, by padding out the previous index map
+  std::vector<std::int64_t> global_indices
+      = adjust_indices(*mesh.topology()->index_map(0), number_of_refined_edges);
+
+  // Build the topology on the new vertices
+  const auto refined_cell_count = mesh.topology()->index_map(1)->size_local()
+                                  + mesh.topology()->index_map(1)->num_ghosts()
+                                  + number_of_refined_edges;
+
+  std::vector<std::int64_t> edge_topology;
+  edge_topology.reserve(refined_cell_count * 2);
+
+  std::vector<std::int32_t> parent_edge;
+  parent_edge.reserve(refined_cell_count);
+
+  for (std::int32_t edge = 0; edge < map_e->size_local(); ++edge)
+  {
+    const auto& vertices = e_to_v->links(edge);
+    assert(vertices.size() == 2);
+
+    // we consider a (previous) edge of (global) vertices
+    // a ----------- b
+    const std::int64_t a = global_indices[vertices[0]];
+    const std::int64_t b = global_indices[vertices[1]];
+
+    if (refinement_marker[edge])
+    {
+      // find (global) index of new midpoint vertex:
+      // a --- c --- b
+      auto it = new_vertex_map.find(edge);
+      assert(it != new_vertex_map.end());
+      const std::int64_t c = it->second;
+
+      // add new edges to refined topology
+      edge_topology.insert(edge_topology.end(), {a, c, c, b});
+      parent_edge.insert(parent_edge.end(), {edge, edge});
+    }
+    else
+    {
+      // copy the previous edge
+      edge_topology.insert(edge_topology.end(), {a, b});
+      parent_edge.push_back(edge);
+    }
+  }
+
+  assert(edge_topology.size() == refined_cell_count * 2);
+  assert(parent_edge.size() == refined_cell_count);
+
+  std::vector<std::int32_t> offsets(refined_cell_count + 1);
+  std::ranges::generate(offsets, [i = 0]() mutable { return 2 * i++; });
+
+  graph::AdjacencyList cell_adj(std::move(edge_topology), std::move(offsets));
+
+  return {std::move(cell_adj), std::move(new_vertex_coords), xshape,
+          std::move(parent_edge)};
+}
+
+} // namespace impl
+
+/// Refines a (topologically) one dimensional mesh by splitting edges.
+///
+/// @param[in] mesh Mesh to be refined
+/// @param[in] edges Optional indices of the edges that should be split by this
+/// refinement. If not provided, all edges are considered marked for refinement,
+/// i.e. a uniform refinement is performed.
+/// @param[in] redistribute Option to enable redistribution of the refined mesh
+/// across processes.
+///
+/// @return Refined mesh, and list of parent edges - for every new edge index
+/// this contains the associated edge index of the pre-refinement mesh.
+template <std::floating_point T>
+std::tuple<mesh::Mesh<T>, std::vector<std::int32_t>>
+refine_interval(const mesh::Mesh<T>& mesh,
+                std::optional<std::span<const std::int32_t>> edges,
+                bool redistribute)
+{
+
+  if (mesh.topology()->cell_type() != mesh::CellType::interval)
+    throw std::runtime_error("Cell type not supported");
+
+  if (!mesh.topology()->index_map(1))
+    throw std::runtime_error("Edges must be initialised");
+
+  assert(mesh.topology()->dim() == 1);
+
+  auto [cell_adj, new_coords, xshape, parent_cell]
+      = impl::compute_interval_refinement(mesh, edges);
+
+  if (dolfinx::MPI::size(mesh.comm()) == 1)
+  {
+    return {mesh::create_mesh(mesh.comm(), cell_adj.array(),
+                              mesh.geometry().cmap(), new_coords, xshape,
+                              mesh::GhostMode::none),
+            std::move(parent_cell)};
+  }
+  else
+  {
+    // Check if mesh has ghost cells on any rank
+    // FIXME: this is not a robust test. Should be user option.
+    const int num_ghost_cells = mesh.topology()->index_map(1)->num_ghosts();
+    int max_ghost_cells = 0;
+    MPI_Allreduce(&num_ghost_cells, &max_ghost_cells, 1, MPI_INT, MPI_MAX,
+                  mesh.comm());
+
+    // Build mesh
+    const auto ghost_mode = max_ghost_cells == 0
+                                ? mesh::GhostMode::none
+                                : mesh::GhostMode::shared_facet;
+
+    return {partition<T>(mesh, cell_adj, std::span(new_coords), xshape,
+                         redistribute, ghost_mode),
+            std::move(parent_cell)};
+  }
+}
+
+} // namespace dolfinx::refinement

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   common/sort.cpp
   mesh/distributed_mesh.cpp
   common/CIFailure.cpp
+  refinement/interval.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/poisson.c
 )
 target_link_libraries(unittests PRIVATE Catch2::Catch2WithMain dolfinx)

--- a/cpp/test/refinement/interval.cpp
+++ b/cpp/test/refinement/interval.cpp
@@ -1,0 +1,290 @@
+// Copyright (C) 2024 Paul Kühner
+//
+// This file is part of DOLFINX (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#include <optional>
+
+#include <mpi.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <dolfinx/common/MPI.h>
+#include <dolfinx/graph/AdjacencyList.h>
+#include <dolfinx/mesh/Mesh.h>
+#include <dolfinx/mesh/generation.h>
+#include <dolfinx/mesh/utils.h>
+#include <dolfinx/refinement/interval.h>
+#include <dolfinx/refinement/refine.h>
+#include <span>
+
+using namespace dolfinx;
+
+mesh::Mesh<double> create_3_vertex_interval_mesh()
+{
+  // creates mesh with vertices
+  std::array<double, 3> v0 = {0., 0., 0.};
+  std::array<double, 3> v1 = {.5, 1., 2.};
+  std::array<double, 3> v2 = {1., 2., 4.};
+
+  // and connectivity
+  // v0 --- v1 --- v2
+  std::vector<std::int64_t> cells{0, 1, 1, 2};
+
+  std::vector<double> x{v0[0], v0[1], v0[2], v1[0], v1[1],
+                        v1[2], v2[0], v2[1], v2[2]};
+  fem::CoordinateElement<double> element(mesh::CellType::interval, 1);
+  return mesh::create_mesh(MPI_COMM_SELF, MPI_COMM_SELF, cells, element,
+                           MPI_COMM_SELF, x, {x.size() / 3, 3},
+                           mesh::create_cell_partitioner());
+}
+
+TEST_CASE("Interval uniform refinement", "refinement,interval,uniform")
+{
+  if (dolfinx::MPI::rank(MPI_COMM_WORLD) > 1)
+    return;
+
+  mesh::Mesh<double> mesh = create_3_vertex_interval_mesh();
+  mesh.topology()->create_connectivity(1, 0);
+
+  auto [refined_mesh, parent_edge]
+      = refinement::refine_interval(mesh, std::nullopt, false);
+
+  // Check geometry
+  {
+    const auto& x = refined_mesh.geometry().x();
+
+    CHECK(x.size() == 15);
+
+    CHECK(x[0] == 0.0);
+    CHECK(x[1] == 0.0);
+    CHECK(x[2] == 0.0);
+
+    CHECK(x[3] == 0.25);
+    CHECK(x[4] == 0.5);
+    CHECK(x[5] == 1.0);
+
+    CHECK(x[6] == 0.5);
+    CHECK(x[7] == 1.0);
+    CHECK(x[8] == 2.0);
+
+    CHECK(x[9] == 0.75);
+    CHECK(x[10] == 1.5);
+    CHECK(x[11] == 3.0);
+
+    CHECK(x[12] == 1.0);
+    CHECK(x[13] == 2.0);
+    CHECK(x[14] == 4.0);
+  }
+
+  // Check topology
+  {
+    auto topology = refined_mesh.topology_mutable();
+    CHECK(topology->dim() == 1);
+
+    topology->create_connectivity(0, 1);
+    auto v_to_e = topology->connectivity(0, 1);
+
+    CHECK(v_to_e->num_links(0) == 1);
+    CHECK(v_to_e->links(0)[0] == 0);
+
+    CHECK(v_to_e->num_links(1) == 2);
+    CHECK(v_to_e->links(1)[0] == 0);
+    CHECK(v_to_e->links(1)[1] == 1);
+
+    CHECK(v_to_e->num_links(2) == 2);
+    CHECK(v_to_e->links(2)[0] == 1);
+    CHECK(v_to_e->links(2)[1] == 2);
+
+    CHECK(v_to_e->num_links(3) == 2);
+    CHECK(v_to_e->links(3)[0] == 2);
+    CHECK(v_to_e->links(3)[1] == 3);
+
+    CHECK(v_to_e->num_links(4) == 1);
+    CHECK(v_to_e->links(4)[0] == 3);
+  }
+
+  // Check parent edges
+  {
+    CHECK(parent_edge.size() == 4);
+
+    CHECK(parent_edge[0] == 0);
+    CHECK(parent_edge[1] == 0);
+    CHECK(parent_edge[2] == 1);
+    CHECK(parent_edge[3] == 1);
+  }
+}
+
+TEST_CASE("Interval adaptive refinement", "refinement,interval,adaptive")
+{
+  if (dolfinx::MPI::rank(MPI_COMM_WORLD) > 1)
+    return;
+
+  mesh::Mesh<double> mesh = create_3_vertex_interval_mesh();
+  mesh.topology()->create_connectivity(1, 0);
+
+  std::vector<std::int32_t> edges{1};
+  auto [refined_mesh, parent_edge]
+      = refinement::refine_interval(mesh, std::span(edges), false);
+
+  // Check geometry
+  {
+    const auto& x = refined_mesh.geometry().x();
+
+    CHECK(x.size() == 12); // -> 5 vertices
+    CHECK(x[0] == 0.0);
+    CHECK(x[1] == 0.0);
+    CHECK(x[2] == 0.0);
+
+    CHECK(x[3] == 0.5);
+    CHECK(x[4] == 1.0);
+    CHECK(x[5] == 2.0);
+
+    CHECK(x[6] == 0.75);
+    CHECK(x[7] == 1.5);
+    CHECK(x[8] == 3.0);
+
+    CHECK(x[9] == 1.0);
+    CHECK(x[10] == 2.0);
+    CHECK(x[11] == 4.0);
+  }
+
+  // Check topology
+  {
+    auto topology = refined_mesh.topology_mutable();
+    CHECK(topology->dim() == 1);
+
+    topology->create_connectivity(0, 1);
+    auto v_to_e = topology->connectivity(0, 1);
+
+    CHECK(v_to_e->num_links(0) == 1);
+    CHECK(v_to_e->links(0)[0] == 0);
+
+    CHECK(v_to_e->num_links(1) == 2);
+    CHECK(v_to_e->links(1)[0] == 0);
+    CHECK(v_to_e->links(1)[1] == 1);
+
+    CHECK(v_to_e->num_links(2) == 2);
+    CHECK(v_to_e->links(2)[0] == 1);
+    CHECK(v_to_e->links(2)[1] == 2);
+
+    CHECK(v_to_e->num_links(3) == 1);
+    CHECK(v_to_e->links(3)[0] == 2);
+  }
+
+  // Check parent edges
+  {
+    CHECK(parent_edge.size() == 3);
+
+    CHECK(parent_edge[0] == 0);
+    CHECK(parent_edge[1] == 1);
+    CHECK(parent_edge[2] == 1);
+  }
+}
+
+TEST_CASE("Interval Refinement (parallel)", "refinement,interval,paralle")
+{
+  /**
+  Produces an interval with communicator size intervals. Every process is
+  assigned one intervall and we refine uniformly.
+  */
+
+  const auto comm_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const auto rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+
+  if (comm_size == 1)
+    return;
+
+  auto create_mesh = [&]()
+  {
+    std::vector<double> x;
+    std::vector<std::int64_t> cells;
+    fem::CoordinateElement<double> element(mesh::CellType::interval, 1);
+    if (rank == 0)
+    {
+      for (std::int64_t i = 0; i < comm_size + 1; i++)
+        x.insert(x.end(), {static_cast<double>(i) / comm_size,
+                           static_cast<double>(i) + 1, 2. * i + comm_size});
+      for (std::int64_t i = 0; i < 2 * comm_size; i++)
+      {
+        auto div = std::div(i, static_cast<std::int64_t>(2));
+        cells.push_back(div.quot + div.rem);
+      }
+    }
+
+    auto partitioner
+        = [](MPI_Comm /* comm */, int /* nparts */,
+             const std::vector<mesh::CellType>& /* cell_types */,
+             const std::vector<std::span<const std::int64_t>>& /* cells */)
+        -> graph::AdjacencyList<std::int32_t>
+    {
+      return graph::AdjacencyList<std::int32_t>(
+          dolfinx::MPI::size(MPI_COMM_WORLD));
+    };
+
+    auto commt = rank == 0 ? MPI_COMM_SELF : MPI_COMM_NULL;
+    return mesh::create_mesh(MPI_COMM_WORLD, commt, cells, element, commt, x,
+                             {x.size() / 3, 3}, partitioner);
+  };
+
+  mesh::Mesh<double> mesh = create_mesh();
+  mesh.topology()->create_connectivity(1, 0);
+
+  // complete refinement
+  {
+    auto [refined_mesh, parent_edges]
+        = refinement::refine_interval(mesh, std::nullopt, false);
+
+    // Check geometry
+    {
+
+      auto x = refined_mesh.geometry().x();
+      CHECK(x.size() == 9);
+
+      std::ranges::sort(x);
+
+      CHECK(x[0] == static_cast<double>(rank) / comm_size);
+      CHECK(x[1]
+            == static_cast<double>(rank) / comm_size + 1. / (2 * comm_size));
+      CHECK(x[2]
+            == static_cast<double>(rank) / comm_size + 2. / (2 * comm_size));
+
+      CHECK(x[3] == rank + 1);
+      CHECK(x[4] == rank + 1.5);
+      CHECK(x[5] == rank + 2);
+
+      CHECK(x[6] == 2 * rank + comm_size);
+      CHECK(x[7] == 2 * (rank + .5) + comm_size);
+      CHECK(x[8] == 2 * (rank + 1) + comm_size);
+    }
+
+    // Check topology
+    {
+      auto topology = refined_mesh.topology_mutable();
+      CHECK(topology->dim() == 1);
+
+      topology->create_connectivity(0, 1);
+      auto v_to_e = topology->connectivity(0, 1);
+
+      // find the center index, i.e. the one with two outgoing edges
+      int center_index = v_to_e->num_links(0) == 2   ? 0
+                         : v_to_e->num_links(1) == 2 ? 1
+                                                     : 2;
+      CHECK(v_to_e->num_links(center_index) == 2);
+      // check it's connected to both edge 0 and 1
+      CHECK(std::ranges::find(v_to_e->links(center_index), 0)
+            != v_to_e->links(center_index).end());
+      CHECK(std::ranges::find(v_to_e->links(center_index), 1)
+            != v_to_e->links(center_index).end());
+
+      // side vertices are only connected to one edge
+      CHECK(v_to_e->links((center_index + 1) % 3).size() == 1);
+      CHECK(v_to_e->links((center_index + 2) % 3).size() == 1);
+
+      // and this edge is not shared
+      CHECK(v_to_e->links((center_index + 1) % 3)[0]
+            != v_to_e->links((center_index + 1) % 3)[1]);
+    }
+  }
+}

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -60,6 +60,7 @@ __all__ = [
     "create_unit_cube",
     "to_type",
     "to_string",
+    "refine_interval",
     "refine_plaza",
     "transfer_meshtag",
     "entities_to_geometry",
@@ -331,6 +332,30 @@ def refine(
     else:
         mesh1 = _cpp.refinement.refine(mesh._cpp_object, edges, redistribute)
     return Mesh(mesh1, mesh._ufl_domain)
+
+
+def refine_interval(
+    mesh: Mesh, edges: typing.Optional[np.ndarray] = None, redistribute: bool = True
+) -> tuple[Mesh, npt.NDArray[np.int32]]:
+    """Refine a (topologically) one dimensional mesh.
+
+    Args:
+        mesh: Mesh to refine
+        edges: Indices of edges to split druing refinement. If ``None``, mesh refinement is uniform.
+        redistribute: Refined mesh is re-partitioned if ``True``.
+
+    Returns:
+        Refined mesh.
+    """
+
+    if edges is None:
+        refined_mesh, parent_edges = _cpp.refinement.refine_interval(mesh._cpp_object, redistribute)
+    else:
+        refined_mesh, parent_edges = _cpp.refinement.refine_interval(
+            mesh._cpp_object, edges, redistribute
+        )
+
+    return Mesh(refined_mesh, mesh._ufl_domain), parent_edges
 
 
 def refine_plaza(

--- a/python/dolfinx/wrappers/refinement.cpp
+++ b/python/dolfinx/wrappers/refinement.cpp
@@ -5,8 +5,10 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "array.h"
+#include <concepts>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/MeshTags.h>
+#include <dolfinx/refinement/interval.h>
 #include <dolfinx/refinement/plaza.h>
 #include <dolfinx/refinement/refine.h>
 #include <dolfinx/refinement/utils.h>
@@ -15,100 +17,96 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
+#include <optional>
 
 namespace nb = nanobind;
 
 namespace dolfinx_wrappers
 {
+
+template <std::floating_point T>
+void export_refinement_with_variable_mesh_type(nb::module_& m)
+{
+  m.def("refine",
+        nb::overload_cast<const dolfinx::mesh::Mesh<T>&, bool>(
+            &dolfinx::refinement::refine<T>),
+        nb::arg("mesh"), nb::arg("redistribute") = true);
+  m.def(
+      "refine",
+      [](const dolfinx::mesh::Mesh<T>& mesh,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> edges,
+         bool redistribute)
+      {
+        return dolfinx::refinement::refine(
+            mesh, std::span(edges.data(), edges.size()), redistribute);
+      },
+      nb::arg("mesh"), nb::arg("edges"), nb::arg("redistribute") = true);
+
+  m.def(
+      "refine_interval",
+      [](const dolfinx::mesh::Mesh<T>& mesh, bool redistribute)
+      {
+        auto [mesh_refined, edges] = dolfinx::refinement::refine_interval(
+            mesh, std::nullopt, redistribute);
+        return std::tuple(std::move(mesh_refined),
+                          as_nbarray(std::move(edges)));
+      },
+      nb::arg("mesh"), nb::arg("redistribute"));
+
+  m.def(
+      "refine_interval",
+      [](const dolfinx::mesh::Mesh<T>& mesh,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> edges,
+         bool redistribute)
+      {
+        auto [mesh_refined, parent_edges]
+            = dolfinx::refinement::refine_interval(
+                mesh, std::make_optional(std::span(edges.data(), edges.size())),
+                redistribute);
+        return std::tuple(std::move(mesh_refined),
+                          as_nbarray(std::move(parent_edges)));
+      },
+      nb::arg("mesh"), nb::arg("edges"), nb::arg("redistribute"));
+
+  m.def(
+      "refine_plaza",
+      [](const dolfinx::mesh::Mesh<T>& mesh0, bool redistribute,
+         dolfinx::refinement::plaza::Option option)
+      {
+        auto [mesh1, cell, facet]
+            = dolfinx::refinement::plaza::refine(mesh0, redistribute, option);
+        return std::tuple{std::move(mesh1), as_nbarray(std::move(cell)),
+                          as_nbarray(std::move(facet))};
+      },
+      nb::arg("mesh"), nb::arg("redistribute"), nb::arg("option"));
+
+  m.def(
+      "refine_plaza",
+      [](const dolfinx::mesh::Mesh<T>& mesh0,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> edges,
+         bool redistribute, dolfinx::refinement::plaza::Option option)
+      {
+        auto [mesh1, cell, facet] = dolfinx::refinement::plaza::refine(
+            mesh0, std::span<const std::int32_t>(edges.data(), edges.size()),
+            redistribute, option);
+        return std::tuple{std::move(mesh1), as_nbarray(std::move(cell)),
+                          as_nbarray(std::move(facet))};
+      },
+      nb::arg("mesh"), nb::arg("edges"), nb::arg("redistribute"),
+      nb::arg("option"));
+}
+
 void refinement(nb::module_& m)
 {
+  export_refinement_with_variable_mesh_type<float>(m);
+  export_refinement_with_variable_mesh_type<double>(m);
+
   nb::enum_<dolfinx::refinement::plaza::Option>(m, "RefinementOption")
       .value("none", dolfinx::refinement::plaza::Option::none)
       .value("parent_facet", dolfinx::refinement::plaza::Option::parent_facet)
       .value("parent_cell", dolfinx::refinement::plaza::Option::parent_cell)
       .value("parent_cell_and_facet",
              dolfinx::refinement::plaza::Option::parent_cell_and_facet);
-
-  // dolfinx::refinement::refine
-  m.def("refine",
-        nb::overload_cast<const dolfinx::mesh::Mesh<float>&, bool>(
-            &dolfinx::refinement::refine<float>),
-        nb::arg("mesh"), nb::arg("redistribute") = true);
-  m.def("refine",
-        nb::overload_cast<const dolfinx::mesh::Mesh<double>&, bool>(
-            &dolfinx::refinement::refine<double>),
-        nb::arg("mesh"), nb::arg("redistribute") = true);
-  m.def(
-      "refine",
-      [](const dolfinx::mesh::Mesh<float>& mesh,
-         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> edges,
-         bool redistribute)
-      {
-        return dolfinx::refinement::refine(
-            mesh, std::span(edges.data(), edges.size()), redistribute);
-      },
-      nb::arg("mesh"), nb::arg("edges"), nb::arg("redistribute") = true);
-  m.def(
-      "refine",
-      [](const dolfinx::mesh::Mesh<double>& mesh,
-         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> edges,
-         bool redistribute)
-      {
-        return dolfinx::refinement::refine(
-            mesh, std::span(edges.data(), edges.size()), redistribute);
-      },
-      nb::arg("mesh"), nb::arg("edges"), nb::arg("redistribute") = true);
-  m.def(
-      "refine_plaza",
-      [](const dolfinx::mesh::Mesh<float>& mesh0, bool redistribute,
-         dolfinx::refinement::plaza::Option option)
-      {
-        auto [mesh1, cell, facet]
-            = dolfinx::refinement::plaza::refine(mesh0, redistribute, option);
-        return std::tuple{std::move(mesh1), as_nbarray(std::move(cell)),
-                          as_nbarray(std::move(facet))};
-      },
-      nb::arg("mesh"), nb::arg("redistribute"), nb::arg("option"));
-  m.def(
-      "refine_plaza",
-      [](const dolfinx::mesh::Mesh<double>& mesh0, bool redistribute,
-         dolfinx::refinement::plaza::Option option)
-      {
-        auto [mesh1, cell, facet]
-            = dolfinx::refinement::plaza::refine(mesh0, redistribute, option);
-        return std::tuple{std::move(mesh1), as_nbarray(std::move(cell)),
-                          as_nbarray(std::move(facet))};
-      },
-      nb::arg("mesh"), nb::arg("redistribute"), nb::arg("option"));
-  m.def(
-      "refine_plaza",
-      [](const dolfinx::mesh::Mesh<float>& mesh0,
-         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> edges,
-         bool redistribute, dolfinx::refinement::plaza::Option option)
-      {
-        auto [mesh1, cell, facet] = dolfinx::refinement::plaza::refine(
-            mesh0, std::span<const std::int32_t>(edges.data(), edges.size()),
-            redistribute, option);
-        return std::tuple{std::move(mesh1), as_nbarray(std::move(cell)),
-                          as_nbarray(std::move(facet))};
-      },
-      nb::arg("mesh"), nb::arg("edges"), nb::arg("redistribute"),
-      nb::arg("option"));
-  m.def(
-      "refine_plaza",
-      [](const dolfinx::mesh::Mesh<double>& mesh0,
-         nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig> edges,
-         bool redistribute, dolfinx::refinement::plaza::Option option)
-      {
-        auto [mesh1, cell, facet] = dolfinx::refinement::plaza::refine(
-            mesh0, std::span<const std::int32_t>(edges.data(), edges.size()),
-            redistribute, option);
-        return std::tuple{std::move(mesh1), as_nbarray(std::move(cell)),
-                          as_nbarray(std::move(facet))};
-      },
-      nb::arg("mesh"), nb::arg("edges"), nb::arg("redistribute"),
-      nb::arg("option"));
-
   m.def(
       "transfer_facet_meshtag",
       [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,

--- a/python/test/unit/refinement/interval.py
+++ b/python/test/unit/refinement/interval.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2024 Paul Kühner
+#
+# This file is part of DOLFINx (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+from mpi4py import MPI
+
+import numpy as np
+import pytest
+
+from dolfinx import mesh
+
+
+@pytest.mark.parametrize(
+    "ghost_mode", [mesh.GhostMode.none, mesh.GhostMode.shared_vertex, mesh.GhostMode.shared_facet]
+)
+@pytest.mark.parametrize("redistribute", [True, False])
+def test_refine_interval(ghost_mode, redistribute):
+    msh = mesh.create_interval(MPI.COMM_WORLD, 100, [0, 1], ghost_mode=ghost_mode)
+    msh_refined, edges = mesh.refine_interval(msh, redistribute=redistribute)
+
+    # vertex count
+    assert msh_refined.topology.index_map(0).size_global == 201
+
+    # edge count
+    edge_count = np.array([len(edges)], dtype=np.int64)
+    edge_count = MPI.COMM_WORLD.allreduce(edge_count)
+
+    assert edge_count == msh_refined.topology.index_map(1).size_global == 200
+
+
+@pytest.mark.parametrize(
+    "ghost_mode", [mesh.GhostMode.none, mesh.GhostMode.shared_vertex, mesh.GhostMode.shared_facet]
+)
+@pytest.mark.parametrize("redistribute", [True, False])
+def test_refine_interval_adaptive(ghost_mode, redistribute):
+    msh = mesh.create_interval(MPI.COMM_WORLD, 100, [0, 1], ghost_mode=ghost_mode)
+    msh_refined, edges = mesh.refine_interval(msh, np.arange(10), redistribute=redistribute)
+
+    # vertex count
+    assert msh_refined.topology.index_map(0).size_global == 101 + 10 * MPI.COMM_WORLD.size
+
+    # edge count
+    edge_count = np.array([len(edges)], dtype=np.int64)
+    edge_count = MPI.COMM_WORLD.allreduce(edge_count)
+
+    assert (
+        edge_count
+        == msh_refined.topology.index_map(1).size_global
+        == 100 + 10 * MPI.COMM_WORLD.size
+    )


### PR DESCRIPTION
Implements a (topological) one dimensional mesh refinement routine.

For now this is not passed through a combined `refine(...)` interface with the 2D and 3D `plaza` refinement routines, but rather provides a standalone one dimensional case.

I'm not to sure about really having tested everything that should be tested, especially the construction of good test cases for different ghost modes is still open, but the construction of these cases is very tedious.