### PR TITLE
Pytest improvements

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -239,9 +239,9 @@ jobs:
         run: python -m pytest -m mpi --num-proc=3 python/demo/test.py
 
       - name: Run Python unit tests (serial)
-        run: python -m pytest -m "petsc4py or adios2" -n=auto --durations=50 python/test/unit/
+        run: python -m pytest -n=auto --durations=50 python/test/unit/
       - name: Run Python unit tests (MPI, np=3)
-        run: mpirun -np 3 python -m pytest -m "petsc4py or adios2" python/test/unit/
+        run: mpirun -np 3 python -m pytest python/test/unit/
 
   publish-docs:
     if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -137,9 +137,9 @@ jobs:
       - name: Run demos (Python, MPI (np=3))
         run: python -m pytest -m mpi --num-proc=3 python/demo/test.py
       - name: Run unit tests
-        run: python -m pytest -n auto -m "not petsc4py" python/test/unit
+        run: python -m pytest -n auto python/test/unit
       - name: Run unit tests (MPI, np=3)
-        run: mpirun -np 3 python -m pytest -m "not petsc4py" python/test/unit
+        run: mpirun -np 3 python -m pytest python/test/unit
 
   build-with-petsc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -137,9 +137,9 @@ jobs:
       - name: Run demos (Python, MPI (np=3))
         run: python -m pytest -m mpi --num-proc=3 python/demo/test.py
       - name: Run unit tests
-        run: python -m pytest -n auto -m "not petsc4py and not adios2" python/test/unit
+        run: python -m pytest -n auto -m "not petsc4py" python/test/unit
       - name: Run unit tests (MPI, np=3)
-        run: mpirun -np 3 python -m pytest -m "not petsc4py and not adios2" python/test/unit
+        run: mpirun -np 3 python -m pytest -m "not petsc4py" python/test/unit
 
   build-with-petsc:
     runs-on: ubuntu-latest

--- a/.github/workflows/oneapi.yml
+++ b/.github/workflows/oneapi.yml
@@ -103,6 +103,6 @@ jobs:
         run: pytest -m mpi --num-proc=2 python/demo/test.py
 
       - name: Run DOLFINx Python unit tests (serial)
-        run: python -m pytest -m "not adios2" -n=auto --durations=50 python/test/unit
+        run: python -m pytest -n=auto --durations=50 python/test/unit
       - name: Run DOLFINx Python unit tests (MPI, np=2)
-        run: mpiexec -n 2 python -m pytest -m "not adios2" python/test/unit
+        run: mpiexec -n 2 python -m pytest python/test/unit

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -83,6 +83,6 @@ jobs:
         run: python3 -m pytest -m mpi --num-proc=2 python/demo/test.py
 
       - name: Run Python unit tests (serial)
-        run: python3 -m pytest -n auto -m "not adios2" --durations=50 python/test/unit/
+        run: python3 -m pytest -n auto --durations=50 python/test/unit/
       - name: Run Python unit tests (MPI, np=2)
-        run: mpirun -np 2 python3 -m pytest -m "not adios2" python/test/unit/
+        run: mpirun -np 2 python3 -m pytest python/test/unit/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -140,11 +140,11 @@ jobs:
       - name: Run units tests (Python, serial)
         working-directory: dolfinx
         run: |
-          python -m pytest -n auto -m "not petsc4py" python/test/unit
+          python -m pytest -n auto python/test/unit
       - name: Run units tests (Python, MPI, np=3)
         working-directory: dolfinx
         run: |
-          mpiexec -n 3 python -m pytest -m "not petsc4py" python/test/unit
+          mpiexec -n 3 python -m pytest python/test/unit
 
       - name: Run Python demos (serial)
         working-directory: dolfinx

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -140,11 +140,11 @@ jobs:
       - name: Run units tests (Python, serial)
         working-directory: dolfinx
         run: |
-          python -m pytest -n auto -m "not petsc4py and not adios2" python/test/unit
+          python -m pytest -n auto -m "not petsc4py" python/test/unit
       - name: Run units tests (Python, MPI, np=3)
         working-directory: dolfinx
         run: |
-          mpiexec -n 3 python -m pytest -m "not petsc4py and not adios2" python/test/unit
+          mpiexec -n 3 python -m pytest -m "not petsc4py" python/test/unit
 
       - name: Run Python demos (serial)
         working-directory: dolfinx

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -61,7 +61,6 @@ junit_family = "xunit2"
 [tool.pytest.ini_options]
 markers = [
             "skip_in_parallel: marks tests that should be run in serial only.",
-            "adios2: tests that require Adios2 (deselect with '-m \"not adios2\"').",
             "xfail_win32_complex: expected failures for complex numbers in Win32."
 ]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -61,7 +61,6 @@ junit_family = "xunit2"
 [tool.pytest.ini_options]
 markers = [
             "skip_in_parallel: marks tests that should be run in serial only.",
-            "petsc4py: tests that require PETSc/petsc4py (deselect with '-m \"not petsc4py\"').",
             "adios2: tests that require Adios2 (deselect with '-m \"not adios2\"').",
             "xfail_win32_complex: expected failures for complex numbers in Win32."
 ]

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -169,7 +169,6 @@ def nest_matrix_norm(A):
     return math.sqrt(norm)
 
 
-@pytest.mark.petsc4py
 @pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 class TestPETScAssemblers:
     @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -18,6 +18,7 @@ import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import cpp as _cpp
 from dolfinx import default_real_type, fem, graph, la
+from dolfinx.common import has_petsc4py
 from dolfinx.fem import (
     Constant,
     Function,
@@ -169,6 +170,7 @@ def nest_matrix_norm(A):
 
 
 @pytest.mark.petsc4py
+@pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 class TestPETScAssemblers:
     @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])
     def test_basic_assembly_petsc_matrixcsr(self, mode):

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -317,7 +317,6 @@ def test_custom_mesh_loop_rank1(dtype):
     assert np.linalg.norm(b3.x.array - b0.x.array) == pytest.approx(0.0, abs=1e-8)
 
 
-@pytest.mark.petsc4py
 @pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 @pytest.mark.parametrize(
     "set_vals,backend",

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -26,6 +26,7 @@ import pytest
 import dolfinx
 import dolfinx.pkgconfig
 import ufl
+from dolfinx.common import has_petsc4py
 from dolfinx.fem import Function, form, functionspace
 from dolfinx.mesh import create_unit_square
 from dolfinx.utils import cffi_utils as petsc_cffi
@@ -317,6 +318,7 @@ def test_custom_mesh_loop_rank1(dtype):
 
 
 @pytest.mark.petsc4py
+@pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 @pytest.mark.parametrize(
     "set_vals,backend",
     [

--- a/python/test/unit/fem/test_petsc_discrete_operators.py
+++ b/python/test/unit/fem/test_petsc_discrete_operators.py
@@ -18,7 +18,6 @@ from dolfinx.fem import Expression, Function, assemble_scalar, form, functionspa
 from dolfinx.mesh import CellType, GhostMode, create_mesh, create_unit_cube, create_unit_square
 
 
-@pytest.mark.petsc4py
 @pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 class TestPETScDiscreteOperators:
     @pytest.mark.skip_in_parallel

--- a/python/test/unit/fem/test_petsc_discrete_operators.py
+++ b/python/test/unit/fem/test_petsc_discrete_operators.py
@@ -13,11 +13,13 @@ import pytest
 import ufl
 from basix.ufl import element
 from dolfinx import default_real_type
+from dolfinx.common import has_petsc4py
 from dolfinx.fem import Expression, Function, assemble_scalar, form, functionspace
 from dolfinx.mesh import CellType, GhostMode, create_mesh, create_unit_cube, create_unit_square
 
 
 @pytest.mark.petsc4py
+@pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 class TestPETScDiscreteOperators:
     @pytest.mark.skip_in_parallel
     @pytest.mark.parametrize(

--- a/python/test/unit/fem/test_petsc_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_petsc_nonlinear_assembler.py
@@ -155,7 +155,6 @@ class NonlinearPDE_SNESProblem:
             P.assemble()
 
 
-@pytest.mark.petsc4py
 @pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 class TestNLSPETSc:
     def test_matrix_assembly_block_nl(self):

--- a/python/test/unit/fem/test_petsc_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_petsc_nonlinear_assembler.py
@@ -15,6 +15,7 @@ import pytest
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import default_real_type
+from dolfinx.common import has_petsc4py
 from dolfinx.fem import (
     Function,
     bcs_by_block,
@@ -155,6 +156,7 @@ class NonlinearPDE_SNESProblem:
 
 
 @pytest.mark.petsc4py
+@pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 class TestNLSPETSc:
     def test_matrix_assembly_block_nl(self):
         """Test assembly of block matrices and vectors into (a) monolithic

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -14,6 +14,7 @@ import pytest
 import ufl
 from basix.ufl import element
 from dolfinx import default_real_type, default_scalar_type
+from dolfinx.common import has_adios2
 from dolfinx.fem import Function, functionspace
 from dolfinx.graph import adjacencylist
 from dolfinx.mesh import CellType, create_mesh, create_unit_cube, create_unit_square
@@ -39,6 +40,7 @@ def generate_mesh(dim: int, simplex: bool, N: int = 5, dtype=None):
 
 
 @pytest.mark.adios2
+@pytest.mark.skipif(not has_adios2, reason="Requires ADIOS2 support")
 class TestFides:
     @pytest.mark.parametrize("dim", [2, 3])
     @pytest.mark.parametrize("simplex", [True, False])
@@ -123,6 +125,7 @@ class TestFides:
 
 
 @pytest.mark.adios2
+@pytest.mark.skipif(not has_adios2, reason="Requires ADIOS2 support")
 class TestVTX:
     @pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="This test should only be run in serial.")
     def test_second_order_vtx(self, tempdir):
@@ -293,6 +296,7 @@ class TestVTX:
         """Test reusage of mesh by VTXWriter."""
         from dolfinx.io import VTXMeshPolicy, VTXWriter
 
+        # TODO: should this really be allowed to just be skipped?
         adios2 = pytest.importorskip("adios2")
 
         mesh = generate_mesh(dim, simplex)

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -39,7 +39,6 @@ def generate_mesh(dim: int, simplex: bool, N: int = 5, dtype=None):
         raise RuntimeError("Unsupported dimension")
 
 
-@pytest.mark.adios2
 @pytest.mark.skipif(not has_adios2, reason="Requires ADIOS2 support")
 class TestFides:
     @pytest.mark.parametrize("dim", [2, 3])
@@ -124,7 +123,6 @@ class TestFides:
                 f.write(t)
 
 
-@pytest.mark.adios2
 @pytest.mark.skipif(not has_adios2, reason="Requires ADIOS2 support")
 class TestVTX:
     @pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="This test should only be run in serial.")

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -13,6 +13,7 @@ import pytest
 import ufl
 from dolfinx import cpp as _cpp
 from dolfinx import default_real_type
+from dolfinx.common import has_petsc4py
 from dolfinx.fem import Function, dirichletbc, form, functionspace, locate_dofs_geometrical
 from dolfinx.mesh import create_unit_square
 from ufl import TestFunction, TrialFunction, derivative, dx, grad, inner
@@ -102,6 +103,7 @@ class NonlinearPDE_SNESProblem:
 
 
 @pytest.mark.petsc4py
+@pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 class TestNLS:
     def test_linear_pde(self):
         """Test Newton solver for a linear PDE."""

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -102,7 +102,6 @@ class NonlinearPDE_SNESProblem:
         J.assemble()
 
 
-@pytest.mark.petsc4py
 @pytest.mark.skipif(not has_petsc4py, reason="Requires petsc4py support")
 class TestNLS:
     def test_linear_pde(self):


### PR DESCRIPTION
Make use of dolfinx compile time flags in favor of pytest markers to select tests to run